### PR TITLE
Fix missing space in if condition in build.sh

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -45,7 +45,7 @@ fi
 
 if [ ! -f linux-image* ]; then
     echo "Looking for kernel image..."
-    if [ ! -f gpd-pocket-kernel-files.zip]; then
+    if [ ! -f gpd-pocket-kernel-files.zip ]; then
 	 if [ ! -f chrisaw-kernel-files.zip ]; then
 	    echo ""
 	    echo ""


### PR DESCRIPTION
There was a missing space, causing a syntax error with `build.sh` preventing the kernel message from being displayed