### PR TITLE
Fix touch screen

### DIFF
--- a/display/gpdtouch.sh
+++ b/display/gpdtouch.sh
@@ -50,6 +50,22 @@ do
 		xrandr --output DSI1 --rotate right
 	fi
 
+    currentaxesswap=$(echo -e $(xinput list-props $id | grep 'Evdev Axes Swap' | cut -d ':' -f2))
+
+	if [ "$currentaxesswap" != "1" ]; then
+		xinput set-prop $id "Evdev Axes Swap" 1
+
+		currentmatrix=$(echo -e $(xinput list-props $id | grep 'Evdev Axes Swap' | cut -d ':' -f2))
+	fi
+
+    currentaxesinversion=$(echo -e $(xinput list-props $id | grep 'Evdev Axis Inversion' | cut -d ':' -f2))
+
+	if [ "$currentaxesinversion" != "1, 0" ]; then
+		xinput set-prop $id "Evdev Axis Inversion" 1 0
+
+		currentmatrix=$(echo -e $(xinput list-props $id | grep 'Evdev Axis Inversion' | cut -d ':' -f2))
+	fi
+
 	sleep 3	
 	# wait for X loading on every try
 done  


### PR DESCRIPTION
When I first received my GPD, the touchscreen worked fine. But after cloning the repo and running update.sh, my touches were not happening where my finger was and the scroll direction was inverted (ie. dragging my finger right would scroll down). I found that tweaking the `Evdev Axes Swap` and `Evdev Axis Inversion` properties of the touch display restored the functionality back to what it was. I don't know if everyone has this problem, but figured since I just got it yesterday, I'd propose the change so someone else could verify it.