### PR TITLE
Passwordless touchpanel reset for indicator

### DIFF
--- a/display/gpd-touchreset-sudoers
+++ b/display/gpd-touchreset-sudoers
@@ -1,0 +1,1 @@
+ALL ALL = NOPASSWD: /usr/local/sbin/gpdtouch touchreset

--- a/update.sh
+++ b/update.sh
@@ -48,6 +48,9 @@ cp 35-screen.conf /etc/X11/xorg.conf.d/35-screen.conf
 cp 40-touch.conf /etc/X11/xorg.conf.d/40-touch.conf
 cp 40-trackpoint.conf /etc/X11/xorg.conf.d/40-trackpoint.conf
 
+# add passwordless touchpanel reset via indicator
+cp gpd-touchreset-sudoers /etc/sudoers.d/gpd.touchreset-sudoers
+
 # remove rules to rotate screen of 90 degree right on driver load
 rm -f /etc/udev/rules.d/99-goodix-touch.rules
 


### PR DESCRIPTION
This removed the need for a password dialog when using the indicator to reset the touchpanel.