### PR TITLE
Remove outdated gksu

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -81,7 +81,6 @@ installpackages+="gstreamer1.0-vaapi "
 installpackages+="vlc "
 # Utilities for traybar rotation indicator and fan handling
 installpackages+="python-gi " # Required by traybar rotation indicator
-installpackages+="gksu " # Required by traybar rotation indicator to reset touchscreen
 installpackages+="git " # Required by traybar rotation indicator to download repository
 installpackages+="python " # Required by traybar rotation indicator & fan script
 installpackages+="gir1.2-appindicator3-0.1 " # Required by traybar rotation indicator


### PR DESCRIPTION
Remove outdated gksu package for bionic, because this removed from repositories.
I created according pull request in gpd-pocket-screen-indicator repository.